### PR TITLE
Move stdin argument to end of exec command, fixes #1

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -8,8 +8,8 @@ DEFAULT_ARGS = [
   '--cache', 'false',
   '--force-exclusion',
   '--format', 'json',
-  '--stdin',
   '--display-style-guide',
+  '--stdin',
 ]
 DEFAULT_MESSAGE = 'Unknown Error'
 WARNINGS = new Set(['refactor', 'convention', 'warning'])
@@ -36,7 +36,7 @@ lint = (editor) ->
   cwd = path.dirname helpers.find filePath, '.'
   stdin = editor.getText()
   stream = 'both'
-  helpers.exec(command[0], command[1..], {cwd, stdin, stream}).then (result) ->
+  helpers.exec(command[0], command[1..], {cwd, stream, stdin}).then (result) ->
     {stdout, stderr} = result
     parsed = try JSON.parse(stdout)
     throw new Error stderr or stdout unless typeof parsed is 'object'


### PR DESCRIPTION
Fixes #1

Looks like this was caused by the version of rubocop (0.49.1) included in ChefDK 2.0.13. The update to rubocop[1] has enforced proper usage of the `--stdin` flag:
>`-s/--stdin requires exactly one path.`

This change moves stdin to the end of the exec command, to comply with the change in rubocop.

[1] https://github.com/bbatsov/rubocop/pull/4226